### PR TITLE
remove duplicate .State on $iis variable

### DIFF
--- a/sitecore-containers-prerequisites.ps1
+++ b/sitecore-containers-prerequisites.ps1
@@ -229,7 +229,7 @@ function Invoke-OperatingSystemCheck {
     ########## Check that IIS is turned OFF  */
     Write-Host "`n`nDETECTING IIS RUNNING STATE..." -ForegroundColor Cyan
 
-    $iis = (Get-CimInstance Win32_Service -Filter "Name='W3svc'").State
+    $iis = (Get-CimInstance Win32_Service -Filter "Name='W3svc'")
     if ($iis.State -eq "Running") {
         Write-Host "X IIS is running.  Turn off IIS." -ForegroundColor Red
     } 


### PR DESCRIPTION
Because the $iis variable that is set on line 232 includes the .State object, the $iis.State check on line 233 was always blank, and therefore always resolved as true, even if IIS was actually running.  I removed .State from 232 so line 233 will resolve correctly.