### PR TITLE
Add check/removal functions for Sitecore license stored in a persisted user environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Checks the machine for Sitecore Container compatibility.
 Quickly verify Sitecore Container:
 - Hardware requirements (CPU, RAM, DISK STORAGE and TYPES)
 - Operating system compatibility (OS Build Version, Hyper-V/Containers Feature Check, IIS Running State)
-- Software requirements (Docker Desktop, Docker engine OS type Linux vs Windows Containers)
+- Software requirements (Docker Desktop, Docker engine OS type Linux vs Windows Containers, Sitecore Docker Tools, Sitecore License persistence in user environment variable)
 - Network Port Check (443, 8079, 8984, 14330)
 
 Download and install software:
@@ -20,6 +20,9 @@ Enable required Windows Features
 Download latest 10.1.0 
 - Container Package ZIP
 - Local Development Installation Guide PDF
+
+Miscellaneous
+- Remove Sitecore license persisted in user environment variable (can be problematic as it overrides session variables in modern Docker solutions)
 
 
 ## Full Scan Demo


### PR DESCRIPTION
Checks/warns/advises if a Sitecore license is stored in a persisted user environment variable. This may interfere with solutions using a license loaded dynamically when starting containers since persisted variables take precedence. When Sitecore License is not persisted in a user environment variable, it works well for Docker solutions where SITECORE_LICENSE variable is set dynamically on container up.

This addresses an issue commonly seen in the #docker channel on Sitecore Slack and in company practice.