### PR TITLE
Add handling of daemon.json missing when Docker not yet run in Windows Containers mode

### DIFF
--- a/sitecore-containers-prerequisites.ps1
+++ b/sitecore-containers-prerequisites.ps1
@@ -278,14 +278,20 @@ function Invoke-SoftwareCheck {
         if ($script:dockerInstalled -eq $true) {
             $dockerProgramFilesPath = "$($drive.DeviceID)\Program Files\Docker";
             if (Test-Path -Path $dockerProgramFilesPath) {
-                $dnsSetting = (Get-Content "$($drive.DeviceID)\ProgramData\Docker\config\daemon.json" | ConvertFrom-Json | Select-Object dns).dns 
-                if (($dnsSetting | Measure-Object).Count -gt 0) {
-                    if ($dnsSetting -match "8.8.8.8") {
-                        Write-Host "+ Docker DNS is set to Google's public DNS server:  $dnsSetting"  -ForegroundColor Green
+                $daemonJsonFile = "$($drive.DeviceID)\ProgramData\Docker\config\daemon.json"
+                if (Test-path -Path $daemonJsonFile) {
+                    $dnsSetting = (Get-Content $daemonJsonFile | ConvertFrom-Json | Select-Object dns).dns 
+                    if (($dnsSetting | Measure-Object).Count -gt 0) {
+                        if ($dnsSetting -match "8.8.8.8") {
+                            Write-Host "+ Docker DNS is set to Google's public DNS server:  $dnsSetting"  -ForegroundColor Green
+                        }
+                        else {
+                            Write-Host "- Docker's '$($drive.DeviceID)\ProgramData\Docker\config\daemon.json' configuration is not set to Google's public DNS server: 8.8.8.8.`nCurrent setting:  $dnsSetting" -ForegroundColor Yellow
+                        }
                     }
-                    else {
-                        Write-Host "- Docker's '$($drive.DeviceID)\ProgramData\Docker\config\daemon.json' configuration is not set to Google's public DNS server: 8.8.8.8.`nCurrent setting:  $dnsSetting" -ForegroundColor Yellow
-                    }
+                }                
+                else {
+                    Write-Host "- Cannot check DNS settings because cannot find the settings file path '$($daemonJsonFile)'. Try making sure you are running Docker Desktop in Windows Containers mode via the GUI or running '$($drive.DeviceID)\Program Files\docker\docker\DockerCLI.exe -SwitchDaemon' if you cannot access the Docker tray icon." -ForegroundColor Yellow
                 }
             }
         }


### PR DESCRIPTION
It seems that if Docker Desktop isn't running (or maybe has never been run) in Windows Containers mode, daemon.json is not present and the check for DNS settings cannot be performed.

This branch has a check for this condition along with messaging to the user to swtich to Windows Containers mode.

Alternatively, the DNS settings check could be moved to after the Windows Containers check, but I didn't want to do too much alteration.