### PR TITLE
Add support for Windows 11 23H2 detection

### DIFF
--- a/sitecore-containers-prerequisites.ps1
+++ b/sitecore-containers-prerequisites.ps1
@@ -224,6 +224,9 @@ function Invoke-OperatingSystemCheck {
             22621 {
                 Write-Host "+ Windows 11 22H2 detected. " -ForegroundColor Green
             }
+            22631 {                
+                Write-Host "+ Windows 11 23H2 detected. " -ForegroundColor Green
+            }
             Default { 
                 $script:OSCheckPassed = $false 
             }


### PR DESCRIPTION
This pull request adds support for detecting Windows 11 23H2 in the operating system check function.